### PR TITLE
Use newer JDK in workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ jobs:
         uses: actions/setup-java@v3
         with:
           distribution: 'temurin'
-          java-version: 11
+          java-version: 17
           cache: 'maven'
       - name: Verify with Maven
         run: |


### PR DESCRIPTION
Locally getting:
```
[INFO] Running com.github.searls.jasmine.io.scripts.FindsScriptLocationsInDirectoryTest
[ERROR] Tests run: 2, Failures: 0, Errors: 1, Skipped: 0, Time elapsed: 0.092 s <<< FAILURE! - in com.github.searls.jasmine.io.scripts.FindsScriptLocationsInDirectoryTest
[ERROR] returnsEmptyWhenDirectoryDoesNotExist  Time elapsed: 0.05 s
[ERROR] addsScriptLocationScannerFinds  Time elapsed: 0.037 s  <<< ERROR!
java.lang.NullPointerException: Cannot invoke "String.indexOf(int)" because the return value of "java.io.File.getPath()" is null
	at com.github.searls.jasmine.io.scripts.FindsScriptLocationsInDirectoryTest.addsScriptLocationScannerFinds(FindsScriptLocationsInDirectoryTest.java:69)
```